### PR TITLE
Adapt to change in NPM package list interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ DGMF outputs dependency graphs to a *Neo4j* graph database instance. Therefore, 
 
 To configure DGMF, you may edit all properties specified in the `system.properties` file. Alternatively, you can configure and control the DGMF interactively in the console when the `interactive-shell` flag is set. The following configuration properties are available:
 
-|Property | Values | Default Value | Description |
-|:---|:---|:---:|:---|
-|`dgm.repo` | {`pypi`, `maven`, `npm`, `nuget`} | npm | Select Repository to work on|
-|`dgm.parallel` | Positive Integers | 10 | Number of parallel streaming pipelines to use. Empirically, we found values between 10 and 30 to be a good fit for most architectures.|
-|`dgm.linkage` | {`pp`, `ap`, `aa`} | pp | Dependency resolution level to use for resolving dependency edges. Either Package-to-Package (`pp`), Artifact-to-Package (`ap`) or Artifact-to-Artifact (`aa`).|
-|`dgm.databaseaddress`| Strings | `bolt://localhost:7687` | Neo4j *Bolt Protocol* URL of form `bolt://<host>:<port>`|
-|`dgm.databaseusername`| Strings | `neo4j` | Username for connecting to Neo4j |
-|`dgm.databasepassword`| Strings | `neo4j` | Password for connecting to Neo4j |
-|`dgm.limit` | Positive Integers | 0 | If limit != 0, mining is stopped after processing the specified number of packages.|
-|`dgm.offset` | Positive Integers | 0 | If offset != 0, the specified number of packages are skipped when building a dependency graph.|
-|`dgm.interactive-shell` | {`true`, `false`} | `false` | If true, DGMF starts an interactive shell session. |
-|`dgm.import-ids`| {`true`, `false`} | `false` | If true, package ids are not generated live, but imported from an id file that was previously exported using DGMF.|
-|`dgm.id-file`| String | `<dgm.repo>_ids.txt`| Only applies if `dgm.import-ids` is `true`. Specifies path to file that holds package ids.|
+| Property                   | Values                            |      Default Value      | Description                                                                                                                                                         |
+|:---------------------------|:----------------------------------|:-----------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `dgm.repo`                 | {`pypi`, `maven`, `npm`, `nuget`} |           npm           | Select Repository to work on                                                                                                                                        |
+| `dgm.parallel`             | Positive Integers                 |           10            | Number of parallel streaming pipelines to use. Empirically, we found values between 10 and 30 to be a good fit for most architectures.                              |
+| `dgm.linkage`              | {`pp`, `ap`, `aa`}                |           pp            | Dependency resolution level to use for resolving dependency edges. Either Package-to-Package (`pp`), Artifact-to-Package (`ap`) or Artifact-to-Artifact (`aa`).     |
+| `dgm.databaseaddress`      | Strings                           | `bolt://localhost:7687` | Neo4j *Bolt Protocol* URL of form `bolt://<host>:<port>`                                                                                                            |
+| `dgm.databaseusername`     | Strings                           |         `neo4j`         | Username for connecting to Neo4j                                                                                                                                    |
+| `dgm.databasepassword`     | Strings                           |         `neo4j`         | Password for connecting to Neo4j                                                                                                                                    |
+| `dgm.limit`                | Positive Integers                 |            0            | If limit != 0, mining is stopped after processing the specified number of packages.                                                                                 |
+| `dgm.offset`               | Positive Integers                 |            0            | If offset != 0, the specified number of packages are skipped when building a dependency graph.                                                                      |
+| `dgm.interactive-shell`    | {`true`, `false`}                 |         `false`         | If true, DGMF starts an interactive shell session.                                                                                                                  |
+| `dgm.import-ids`           | {`true`, `false`}                 |         `false`         | If true, package ids are not generated live, but imported from an id file that was previously exported using DGMF.                                                  |
+| `dgm.id-file`              | String                            |  `<dgm.repo>_ids.txt`   | Only applies if `dgm.import-ids` is `true`. Specifies path to file that holds package ids.                                                                          |
+| `dgm.npm.commit-qualifier` | String                            |        `master`         | Sets which commit or branch of [Connor White's NPM package list](https://github.com/bconnorwhite/all-package-names) shall be used to generate the NPM package list. |
 
 ### Building DGMF locally
 You can build the DGMF executable `.jar` file locally on your machine. To do this, you need to execute to following command:

--- a/src/main/java/Application/Commands/StartCommand.java
+++ b/src/main/java/Application/Commands/StartCommand.java
@@ -46,6 +46,6 @@ public class StartCommand implements Command {
 
     @Override
     public String getDescription() {
-        return "- Command 'start <repository>(optional)': starts a new task with given repository";
+        return "- Command 'start [<repository>]': starts a new task with given repository";
     }
 }

--- a/src/main/java/Application/Commands/UpdateCommand.java
+++ b/src/main/java/Application/Commands/UpdateCommand.java
@@ -44,6 +44,6 @@ public class UpdateCommand implements Command {
 
     @Override
     public String getDescription() {
-        return null;
+        return "- Command 'update [<repository>]': update the graph of the given repository";
     }
 }

--- a/src/main/java/Application/ConsoleApplication.java
+++ b/src/main/java/Application/ConsoleApplication.java
@@ -26,7 +26,7 @@ public class ConsoleApplication {
     }
 
     public static void main(String[] args){
-        if (args.length == 0 || args[0].equals("help")) {
+        if (args == null || args.length == 0 || args[0].equals("help")) {
             printUsage();
             System.exit(-1);
         }

--- a/src/main/java/Repositories/NPM/NpmIdGenerator.java
+++ b/src/main/java/Repositories/NPM/NpmIdGenerator.java
@@ -12,14 +12,18 @@ import java.util.List;
 import java.util.Properties;
 
 public class NpmIdGenerator implements RepositoryController.IdGenerator {
-
-    private static final String allPackagesUrlGitHub = "https://raw.githubusercontent.com/bconnorwhite/all-package-names/master/data/all.json?raw=true";
+    //private static final String allPackagesUrlGitHub = "https://raw.githubusercontent.com/bconnorwhite/all-package-names/7370fbe7a24c6206cae32c0584cedbd5d2f60616/data/all.json.gz?raw=true";
     private static final String packageArrayJsonKey = "packageNames";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private int limit = -1;
     private int offset = 0;
+
+    private static String allPackagesUrlGitHub() {
+        String commitQualifier = System.getProperties().getOrDefault("dgm.npm.commit-qualifier", "master").toString();
+        return "https://raw.githubusercontent.com/bconnorwhite/all-package-names/" + commitQualifier + "/data/all.json.gz?raw=true";
+    }
 
     public NpmIdGenerator() {
         Properties props = System.getProperties();
@@ -33,12 +37,14 @@ public class NpmIdGenerator implements RepositoryController.IdGenerator {
 
         logger.debug("Starting to retrieve NPM ids from GitHub...");
 
-        JSONObject responseObj = HttpUtilities.getContentAsJSON(allPackagesUrlGitHub);
+        JSONObject responseObj = HttpUtilities.getGZIPContent(allPackagesUrlGitHub());
 
         if(responseObj != null && responseObj.has(packageArrayJsonKey)){
             JSONArray packageNames = responseObj.getJSONArray(packageArrayJsonKey);
 
-            List<String> plainPackageNames = new ArrayList<>(packageNames.length());
+            logger.debug("Got a total of " + packageNames.length() + " package names");
+
+            List<String> plainPackageNames = new ArrayList<>(Math.min(packageNames.length(), limit));
 
             for(int i = offset ; i < packageNames.length() ; i++){
                 plainPackageNames.add(packageNames.getString(i));

--- a/src/main/java/Repositories/NPM/NpmIdGenerator.java
+++ b/src/main/java/Repositories/NPM/NpmIdGenerator.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Properties;
 
 public class NpmIdGenerator implements RepositoryController.IdGenerator {
-    //private static final String allPackagesUrlGitHub = "https://raw.githubusercontent.com/bconnorwhite/all-package-names/7370fbe7a24c6206cae32c0584cedbd5d2f60616/data/all.json.gz?raw=true";
+
     private static final String packageArrayJsonKey = "packageNames";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/src/main/java/Utilities/CommandUtilities.java
+++ b/src/main/java/Utilities/CommandUtilities.java
@@ -92,7 +92,7 @@ public final class CommandUtilities {
                     logger.warn("Invalid value for '" + key + "', boolean values expected. Supported: 'true', 'false'");
                     return false;
                 }
-                case "dgm.id-file" -> {
+                case "dgm.id-file", "dgm.npm.commit-qualifier" -> {
                     return !value.isBlank();
                 }
                 default -> {


### PR DESCRIPTION
This PR closes #1, which mentioned that the `NpmIdGenerator` does not work anymore, since the [all-package-names](https://github.com/bconnorwhite/all-package-names) repository now stores the package list as a `.json.gz` file, instead of plain `.json`.

This PR changes the `NpmIdGenerator` so that it now correctly decompresses the file before processing it. It also adds a new configuration option `dgm.npm.commit-qualifier` which allows users to specify the exact commit of the `all-package-names` repo to use when generating NPM ids. This was needed because the latest commit of the repository seems to contain a broken `.json.gz` file, see [this issue](https://github.com/bconnorwhite/all-package-names/issues/5) for details. The configuration option is optional and defaults to `master`, which always selects the most recent version available.

Also the PR integrates some minor optimizations to the description of other DGMF commands.